### PR TITLE
Two small tweaks that improve jQuery tracking + a typo fix

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -208,9 +208,9 @@
         },
 
         isjQueryPresent: function () {
-            // Currently only 1.7.x version supported
+            // Currently only versions 1.7.x and 1.8.x are supported
             return (typeof jQuery === 'function') && ('fn' in jQuery) && ('jquery' in jQuery.fn)
-                    && (jQuery.fn.jquery.indexOf('1.7') === 0)
+                    && (jQuery.fn.jquery.indexOf('1.7') === 0 || jQuery.fn.jquery.indexOf('1.8') === 0)
         },
         
         /*


### PR DESCRIPTION
This pull request fixes a problem with jQuery callbacks that do "return false;". Although not the best practice (as compared to using `preventDefault` and `stopPropagation`), it is something that is often seen in jQuery code.

It also enables jQuery 1.8.x tracking and fixes a typo.
