### PR TITLE
Make it possible to setup onerror manually

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -329,6 +329,9 @@
             variable: 'outputFormat',
             namespace: 'options'
         }, {
+            variable: 'logOnError',
+            namespace: 'options'
+        }, {
             methodName: 'setTrackJQ',
             variable: 'trackJQ',
             namespace: 'options',
@@ -365,7 +368,8 @@
         this.options = Util.merge({}, Config.options);
         this.xmlData = Util.merge(this.DEF_XML_DATA, Config.xmlData);
     }
-    
+
+    window.Airbrake.Notifier = Notifier
     Notifier.prototype = {
         constructor: Notifier,
         VERSION: '0.2.0',
@@ -662,12 +666,14 @@
     };
 
     window.onerror = function (message, file, line) {
-        setTimeout(function () {
-            new Notifier().notify({
-                message: message,
-                stack: '()@' + file + ':' + line
-            });
-        }, 0);
+        if (Airbrake.getLogOnError() != false) {
+            setTimeout(function () {
+                new Notifier().notify({
+                    message: message,
+                    stack: '()@' + file + ':' + line
+                });
+            }, 0);
+        }
 
         return true;
     };


### PR DESCRIPTION
I've added a new option logOnError as well as exposed the Notifier so that it's possible to manually setup the onerror handling.

If you set `Airbrake.setLogOnError(false);` the script will no longer automatically send notifications.

I've done this because in our project, we've got special handling for some of the 3rd party libs we use. These libs (such as Highcharts) will throw an error but it can be taken care of and we do not wish to notify Airbrake in such instances.

If the error is deemed significant we notify Airbrake using

``` javascript
new Airbrake.Notifier().notify({
  message: ex,
  stack: '()@' + url + ':' + line
})
```

Hope someone else finds this useful as well.
