### PR TITLE
Set guid on wrapped jQuery.fn.on, so that caller can remove registered handlers

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -187,7 +187,8 @@
                     }
 
                     // If the function is found, then subscribe wrapped event handler function
-                    args[fnArgIdx] = (function (fnOriginHandler) {
+                    var origFn = args[fnArgIdx],
+                        wrappedFn = (function (fnOriginHandler) {
                         return function() {
                             try {
                                 fnOriginHandler.apply(this, arguments);
@@ -195,8 +196,11 @@
                                 Global.captureException(e);
                             }
                         };
-                    })(args[fnArgIdx]);
+                    })(origFn);
                     
+                    // Use same guid so caller can remove using origFn
+                    wrappedFn.guid = origFn.guid || ( origFn.guid = jQuery.guid++ );
+
                     // Call original jQuery.fn.on, with the same list of arguments, but 
                     // a function replaced with a proxy.
                     return Config.jQuery_fn_on_original.apply(this, args);


### PR DESCRIPTION
jQuery adds `guid`s to callback functions, so they can be removed later. The airbrake callback wrapping code was removing these guids, so jquery-ui sliders were breaking (mouse-move handlers weren't being de-registered.)

This commit fixes the function guid, and jQuery does the same thing internally when wrapping callbacks: https://github.com/jquery/jquery/blob/master/src/event.js#L761-762
