### PR TITLE
Remove try. Rewrite wrap. Don't swallow exceptions. Remove capture, use push instead.

### DIFF
--- a/test/unit/client_test.coffee
+++ b/test/unit/client_test.coffee
@@ -94,7 +94,7 @@ describe "Client", ->
       client.addSession(key2: "[custom_session_key1_value2]")
       expect(client.getSession().key1).to.equal("[custom_session_key1_value]")
 
-  describe "capture", ->
+  describe "push", ->
     exception = do ->
       error = undefined
       try
@@ -106,9 +106,9 @@ describe "Client", ->
 
     it "is aliased as push", ->
       client = new Client()
-      expect(client.push).to.equal(client.capture)
+      expect(client.push).to.equal(client.push)
 
-    describe "with captured calls to processor", ->
+    describe "with pushed calls to processor", ->
       it "processes with processor", ->
         processor = { process: sinon.spy() }
         reporter = { report: sinon.spy() }
@@ -116,7 +116,7 @@ describe "Client", ->
         getReporter = -> reporter
 
         client = new Client(getProcessor, getReporter)
-        client.capture(exception)
+        client.push(exception)
 
         expect(processor.process).to.have.been.called
 
@@ -127,7 +127,7 @@ describe "Client", ->
         getProcessor = -> processor
 
         client = new Client(getProcessor, getReporter)
-        client.capture(exception)
+        client.push(exception)
 
         # Reporter is not called until Processor invokes the
         # callback provided
@@ -141,26 +141,6 @@ describe "Client", ->
 
         expect(reporter.report).to.have.been.calledWith(processed_error)
 
-      it "ignores errors thrown by processor", ->
-        processor = { process: -> throw(new Error("Processor Error")) }
-        reporter = { report: sinon.spy() }
-        getProcessor = -> processor
-        getReporter = -> reporter
-        client = new Client(getProcessor, getReporter)
-
-        run = -> client.capture(exception)
-        expect(run).not.to.throw()
-
-      it "ignores errors thrown by reporter", ->
-        processor = { process: sinon.spy() }
-        reporter = { report: -> throw(new Error("Reporter Error")) }
-        getProcessor = -> processor
-        getReporter = -> reporter
-        client = new Client(getProcessor, getReporter)
-
-        run = -> client.capture(exception)
-        expect(run).not.to.throw()
-
     describe "custom data sent to reporter", ->
      it "reports context", ->
         reporter = { report: sinon.spy() }
@@ -170,7 +150,7 @@ describe "Client", ->
 
         client = new Client(getProcessor, getReporter)
         client.addContext(context_key: "[custom_context]")
-        client.capture(exception)
+        client.push(exception)
 
         reported = reporter.report.lastCall.args[1]
         expect(reported.context.context_key).to.equal("[custom_context]")
@@ -183,7 +163,7 @@ describe "Client", ->
 
         client = new Client(getProcessor, getReporter)
         client.addEnvironment(env_key: "[custom_env]")
-        client.capture(exception)
+        client.push(exception)
 
         reported = reporter.report.lastCall.args[1]
         expect(reported.environment.env_key).to.equal("[custom_env]")
@@ -196,7 +176,7 @@ describe "Client", ->
 
         client = new Client(getProcessor, getReporter)
         client.addParams(params_key: "[custom_params]")
-        client.capture(exception)
+        client.push(exception)
 
         reported = reporter.report.lastCall.args[1]
         expect(reported.params.params_key).to.equal("[custom_params]")
@@ -209,7 +189,7 @@ describe "Client", ->
 
         client = new Client(getProcessor, getReporter)
         client.addSession(session_key: "[custom_session]")
-        client.capture(exception)
+        client.push(exception)
 
         reported = reporter.report.lastCall.args[1]
         expect(reported.session.session_key).to.equal("[custom_session]")
@@ -222,7 +202,7 @@ describe "Client", ->
           getProcessor = -> processor
 
           client = new Client(getProcessor, getReporter)
-          client.capture(error: exception)
+          client.push(error: exception)
           expect(processor.process).to.have.been.calledWith(exception)
 
         it "reports custom context", ->
@@ -233,18 +213,18 @@ describe "Client", ->
 
           client = new Client(getProcessor, getReporter)
           client.addContext(context1: "value1", context2: "value2")
-          client.capture
+          client.push
             error: exception
             context:
-              context1: "capture_value1"
-              context3: "capture_value3"
+              context1: "push_value1"
+              context3: "push_value3"
 
           reported = reporter.report.lastCall.args[1]
           expect(reported.context).to.deep.equal
             language: "JavaScript"
-            context1: "capture_value1"
+            context1: "push_value1"
             context2: "value2"
-            context3: "capture_value3"
+            context3: "push_value3"
 
         it "reports custom environment", ->
           reporter = { report: sinon.spy() }
@@ -254,17 +234,17 @@ describe "Client", ->
 
           client = new Client(getProcessor, getReporter)
           client.addEnvironment(env1: "value1", env2: "value2")
-          client.capture
+          client.push
             error: exception
             environment:
-              env1: "capture_value1"
-              env3: "capture_value3"
+              env1: "push_value1"
+              env3: "push_value3"
 
           reported = reporter.report.lastCall.args[1]
           expect(reported.environment).to.deep.equal
-            env1: "capture_value1"
+            env1: "push_value1"
             env2: "value2"
-            env3: "capture_value3"
+            env3: "push_value3"
 
         it "reports custom params", ->
           reporter = { report: sinon.spy() }
@@ -274,17 +254,17 @@ describe "Client", ->
 
           client = new Client(getProcessor, getReporter)
           client.addParams(param1: "value1", param2: "value2")
-          client.capture
+          client.push
             error: exception
             params:
-              param1: "capture_value1"
-              param3: "capture_value3"
+              param1: "push_value1"
+              param3: "push_value3"
 
           reported = reporter.report.lastCall.args[1]
           expect(reported.params).to.deep.equal
-            param1: "capture_value1"
+            param1: "push_value1"
             param2: "value2"
-            param3: "capture_value3"
+            param3: "push_value3"
 
         it "reports custom session", ->
           reporter = { report: sinon.spy() }
@@ -294,17 +274,17 @@ describe "Client", ->
 
           client = new Client(getProcessor, getReporter)
           client.addSession(session1: "value1", session2: "value2")
-          client.capture
+          client.push
             error: exception
             session:
-              session1: "capture_value1"
-              session3: "capture_value3"
+              session1: "push_value1"
+              session3: "push_value3"
 
           reported = reporter.report.lastCall.args[1]
           expect(reported.session).to.deep.equal
-            session1: "capture_value1"
+            session1: "push_value1"
             session2: "value2"
-            session3: "capture_value3"
+            session3: "push_value3"
 
   it "processes extant errors", ->
     setTimeout = sinon.spy(global, 'setTimeout')
@@ -316,55 +296,9 @@ describe "Client", ->
     deferredFunction()
     expect(processor.process).to.have.been.calledWith("extant error")
 
-  describe "try", ->
-    it "executes lambda", ->
-      client = new Client()
-      lambda = sinon.spy()
-      client.try(lambda)
-      expect(lambda).to.have.been.called
-
-    it "catches error thrown by lambda", ->
-      getProcessor = -> { processor: -> }
-      getReporter = -> { report: -> }
-      client = new Client(getProcessor, getReporter)
-      error = "An error"
-      tryAndThrow = -> client.try(-> throw(error))
-      expect(tryAndThrow).not.to.throw(error)
-
-    it "captures error thrown by lambda", ->
-      processor = { process: sinon.spy() }
-      getProcessor = -> processor
-      getReporter = -> { report: -> }
-      client = new Client(getProcessor, getReporter)
-      error = "An error"
-      client.try -> throw(error)
-      expect(processor.process).to.have.been.calledWith(error)
-
-    it "returns value from lambda", ->
-      client = new Client()
-      lambda = -> 'expected return value'
-      expect(client.try(lambda)).to.equal('expected return value')
-
-    it "binds lambda", ->
-      client = new Client()
-      expectedContext = {}
-      calledContext = undefined
-      lambda = -> calledContext = this
-      client.try(lambda, expectedContext)
-      expect(calledContext).to.equal(expectedContext)
-
   describe "wrap", ->
     it "does not invoke lambda immediately", ->
       client = new Client()
       lambda = sinon.spy()
       client.wrap(lambda)
       expect(lambda).not.to.have.been.called
-
-    it "returns lambda trying supplied lambda", ->
-      client = new Client()
-      trySpy = sinon.spy(client, 'try')
-      lambda = sinon.spy()
-      wrapped = client.wrap(lambda)
-      wrapped()
-      expect(trySpy).to.have.been.calledWith(lambda)
-      expect(lambda).to.have.been.called


### PR DESCRIPTION
So I am trying to add JS notifier to Airbrake and it hardly works. These are small changes I made to local copy:
- removed try. I don't want us to recommend calling functions via Aibrake.try(funcname, arg1, arg2). I would hate such code.
- rewrote wrap. Now it can be used like this:
  jQuery.fn.ready = Airbrake.wrap(jQuery.fn.ready);
- removed capture function. Why do we have both capture and push, but only push is always available?
- copy client's wrap function in case client modified it. Spent few hours debugging this.
- don't swallow exceptions. Yes, we should not raise exceptions there, but that does not mean that we should silently ignore them.
