### PR TITLE
Updated Readme.md to reflect no dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note that notifier shim is loaded after jQuery but before application code. This
 
 Look at [examples](https://github.com/airbrake/airbrake-js/tree/master/examples) for the notifier shim integrated with jQuery.
 
-Note that the above example reflects a typical setup in a probject using jQuery, however jQuery is not a dependency for the notifier shim.
+Note that the above example reflects a typical setup in a project using jQuery, however jQuery is not a dependency for Airbrake-JS. Airbrake-JS has no dependencies.
 
 ## Basic Usage
 


### PR DESCRIPTION
Airbrake notifier shim has no dependencies.
