### PR TITLE
Add necessary dependencies for grunt test and grunt serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "through": "~2.3.4",
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-mocha-cli": "~1.5.0",
+    "grunt-contrib-connect":"~0.6.0",
+    "coffee-script": "~1.6.3",
     "chai": "~1.8.1",
     "sinon": "~1.7.3",
     "sinon-chai": "~2.4.0"


### PR DESCRIPTION
`grunt test` and `grunt serve` fail on a fresh npm install. This should fix that.
