### PR TITLE
Fix console.debug checks

### DIFF
--- a/src/processors/stack.coffee
+++ b/src/processors/stack.coffee
@@ -112,7 +112,7 @@ parseStack = (e, stack) ->
     if m
       continue
 
-    console.debug("airbrake: can't parse", line)
+    console?.debug?("airbrake: can't parse", line)
     backtrace.push({
       function: '',
       file: line,

--- a/src/reporters/jsonp.coffee
+++ b/src/reporters/jsonp.coffee
@@ -8,8 +8,7 @@ report = (notice, opts) ->
 
   cbName = "airbrakeCb" + String(cbCount)
   global[cbName] = (resp) ->
-    if console?.debug?
-      console.debug("airbrake: error #%s was reported: %s", resp.id, resp.url)
+    console?.debug?("airbrake: error #%s was reported: %s", resp.id, resp.url)
     delete global[cbName]
 
   payload = encodeURIComponent(jsonifyNotice(notice))


### PR DESCRIPTION
This fixes an error occurring in `src/processors/stack.coffee` due to there being no check and cleans up a check in `src/reporters/jsonp.coffee` to be done inline.

There's a third place that `console.debug` is called, but it has an if check that prevents logic from happening if `console.debug` isn't defined/a function.

Please let me know if there's anything else you need here.
