### PR TITLE
add console.warn for user if jquery is not found on the page

### DIFF
--- a/examples/airbrake-shim.js
+++ b/examples/airbrake-shim.js
@@ -55,6 +55,12 @@ if (window.addEventListener) {
 }
 
 // Reports exceptions thrown in jQuery event handlers.
+if (!window.jQuery) {
+  console.warn("jQuery not found on the page.  " +
+    "You should remove jQuery integration code from airbrake-shim, or ensure that airbrake-shim is loaded after jQuery");
+  return;
+}
+
 var jqEventAdd = jQuery.event.add;
 jQuery.event.add = function(elem, types, handler, data, selector) {
   if (handler.handler) {


### PR DESCRIPTION
This would have helped clear up some of my confusion earlier, as I thought the
jquery integration was required in the shim.

It also makes it possible to use the shim on pages without jquery as it
returns early if jquery is not found.  In our application jquery is loaded on
some pages, but not all.
