### PR TITLE
move setupJQ() call after definition

### DIFF
--- a/examples/airbrake-shim.js
+++ b/examples/airbrake-shim.js
@@ -54,13 +54,6 @@ if (window.addEventListener) {
   window.attachEvent('onload', loadAirbrakeNotifier);
 }
 
-// Reports exceptions thrown in jQuery event handlers.
-if (window.jQuery) {
-  setupJQ();
-} else {
-  console.warn('airbrake: jQuery not found; skipping jQuery instrumentation.');
-}
-
 var setupJQ = function() {
   var jqEventAdd = jQuery.event.add;
   jQuery.event.add = function(elem, types, handler, data, selector) {
@@ -100,6 +93,13 @@ var setupJQ = function() {
   jQuery.fn.ready = function(fn) {
     return jqReady(Airbrake.wrap(fn));
   }
+}
+
+// Reports exceptions thrown in jQuery event handlers.
+if (window.jQuery) {
+  setupJQ();
+} else {
+  console.warn('airbrake: jQuery not found; skipping jQuery instrumentation.');
 }
 
 })(window);


### PR DESCRIPTION
When `setupJQ` is called before definition it causes a problem in many browsers (latest Firefox, Chrome and Safari)

```
TypeError: setupJQ is not a function application.js:12826
undefined application.js:12825
"TypeError: setupJQ is not a function
 in http://localhost:3000/assets/application.js:12826
"
```
