### PR TITLE
processor: handle uncaught exception messages.

### DIFF
--- a/src/processors/stack.coffee
+++ b/src/processors/stack.coffee
@@ -120,7 +120,7 @@ typeMessageRe = /// ^
 $ ///
 
 processor = (e, cb) ->
-  processorName = ''
+  processorName = 'nostack'
   stack = e.stack or ''
   lines = stack.split('\n')
 
@@ -161,7 +161,18 @@ processor = (e, cb) ->
     type = e.name
     msg = type + ': ' + msg
   else
-    type = ''
+    # Extract type from messages like "Uncaught Exception: message.".
+    uncaughtExcRe = ///^
+      Uncaught\s
+      (.+?)      # type
+      :\s
+      .+         # message
+    $///
+    m = msg.match(uncaughtExcRe)
+    if m
+      type = m[1]
+    else
+      type = ''
 
   return cb(processorName, {
     'type': type,

--- a/test/unit/processors/stack_test.coffee
+++ b/test/unit/processors/stack_test.coffee
@@ -444,3 +444,22 @@ describe "stack processor", ->
         }
       ]
       expect(backtrace).to.deep.equal(wanted)
+
+  context "when called with message only", ->
+    cb = null
+
+    beforeEach ->
+      e = 'Uncaught SecurityError: Blocked a frame with origin "https://airbrake.io" from accessing a cross-origin frame.'
+      cb = sinon.spy()
+      processor(e, cb)
+
+    it "receives nostack processor name", ->
+      expect(cb).to.have.been.called
+      name = cb.lastCall.args[0]
+      expect(name).to.equal("nostack")
+
+    it "receives error message and extracted error type", ->
+      expect(cb).to.have.been.called
+      err = cb.lastCall.args[1]
+      expect(err.type).to.equal("SecurityError")
+      expect(err.message).to.equal('Uncaught SecurityError: Blocked a frame with origin "https://airbrake.io" from accessing a cross-origin frame.')


### PR DESCRIPTION
This PR teaches airbrake-js to extract error class from messages like 'Uncaught SecurityError: Blocked a frame with origin "https://airbrake.io" from accessing a cross-origin frame.'.
