### PR TITLE
Allow to set custom host for receiving reports

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -14,6 +14,8 @@ class Client
     @_projectId = 0
     @_projectKey = ''
 
+    @_host = 'https://api.airbrake.io'
+
     @_context = {}
     @_params = {}
     @_env = {}
@@ -29,6 +31,9 @@ class Client
   setProject: (id, key) ->
     @_projectId = id
     @_projectKey = key
+
+  setHost: (host) ->
+    @_host = host
 
   addContext: (context) ->
     merge(@_context, context)
@@ -78,7 +83,7 @@ class Client
           return
 
       for reporterFn in @_reporters
-        reporterFn(notice, {projectId: @_projectId, projectKey: @_projectKey})
+        reporterFn(notice, {projectId: @_projectId, projectKey: @_projectKey, host: @_host})
 
       return
 

--- a/src/reporters/jsonp.coffee
+++ b/src/reporters/jsonp.coffee
@@ -15,7 +15,7 @@ report = (notice, opts) ->
       global[cbName] = undefined
 
   payload = encodeURIComponent(jsonifyNotice(notice))
-  url = "https://api.airbrake.io/api/v3/projects/#{opts.projectId}/create-notice?key=#{opts.projectKey}&callback=#{cbName}&body=#{payload}"
+  url = "#{opts.host}/api/v3/projects/#{opts.projectId}/create-notice?key=#{opts.projectKey}&callback=#{cbName}&body=#{payload}"
 
   document = global.document
   head = document.getElementsByTagName('head')[0]

--- a/src/reporters/xhr.coffee
+++ b/src/reporters/xhr.coffee
@@ -2,7 +2,7 @@ jsonifyNotice = require('../util/jsonify_notice.coffee')
 
 
 report = (notice, opts) ->
-  url = "https://api.airbrake.io/api/v3/projects/#{opts.projectId}/notices?key=#{opts.projectKey}"
+  url = "#{opts.host}/api/v3/projects/#{opts.projectId}/notices?key=#{opts.projectKey}"
   payload = jsonifyNotice(notice)
 
   req = new global.XMLHttpRequest()

--- a/src/util/slurp_config_from_dom.coffee
+++ b/src/util/slurp_config_from_dom.coffee
@@ -15,6 +15,10 @@ module.exports = (client) ->
     if envName
       client.setEnvironmentName(envName)
 
+    host = attr(script, 'host')
+    if host
+      client.setHost(host)
+
     onload = attr(script, 'onload')
     if onload
       global[onload](client)

--- a/test/unit/client_test.coffee
+++ b/test/unit/client_test.coffee
@@ -81,8 +81,18 @@ describe "Client", ->
         opts = reporter.lastCall.args[1]
         expect(opts).to.deep.equal({
           projectId: 999
-          projectKey: "custom_project_key"
+          projectKey: "custom_project_key",
+          host: "https://api.airbrake.io"
         })
+      it "reporter is called with custom host", ->
+        reporter = sinon.spy()
+
+        client = new Client(writeThroughProcessor, reporter)
+        client.setHost("https://custom.domain.com")
+        client.push(exception)
+
+        reported = reporter.lastCall.args[1]
+        expect(reported.host).to.equal("https://custom.domain.com")
 
     describe "custom data sent to reporter", ->
       it "reports context", ->

--- a/test/unit/reporters/jsonp_test.coffee
+++ b/test/unit/reporters/jsonp_test.coffee
@@ -1,0 +1,32 @@
+expect = require("chai").expect
+sinon = require("sinon")
+
+reporter = require("../../../src/reporters/jsonp")
+
+MockHead = ->
+MockHead.prototype = {
+  appendChild: ->
+  removeChild: ->
+}
+
+MockDocument = ->
+MockDocument.prototype = {
+  getElementsByTagName: ->
+    [new MockHead]
+}
+
+describe "JSONPReporter", ->
+  oldDocument = null
+  beforeEach ->
+    oldDocument = global.document
+    global.document = new MockDocument
+  afterEach ->
+    global.document = oldDocument
+
+  describe "report", ->
+    it "creates script tag with custom host", ->
+      mock = sinon.mock({})
+      MockDocument.prototype.createElement = ->
+        mock
+      reporter({}, {projectId: '[project_id]', projectKey: '[project_key]', host: 'https://custom.domain.com'})
+      expect(mock.src).to.contain('https://custom.domain.com')

--- a/test/unit/reporters/xhr_test.coffee
+++ b/test/unit/reporters/xhr_test.coffee
@@ -21,5 +21,12 @@ describe "XhrReporter", ->
   describe "report", ->
     it "opens async POST to url", ->
       spy = sinon.spy(global.XMLHttpRequest.prototype, 'open')
-      reporter({}, {projectId: '[project_id]', projectKey: '[project_key]'})
+      reporter({}, {projectId: '[project_id]', projectKey: '[project_key]', host: 'https://api.airbrake.io'})
       expect(spy).to.have.been.calledWith("POST", "https://api.airbrake.io/api/v3/projects/[project_id]/notices?key=[project_key]", true)
+      global.XMLHttpRequest.prototype.open.restore()
+
+    it "opens POST to custom url", ->
+      spy = sinon.spy(global.XMLHttpRequest.prototype, 'open')
+      reporter({}, {projectId: '[project_id]', projectKey: '[project_key]', host: 'https://custom.domain.com'})
+      expect(spy).to.have.been.calledWith("POST", "https://custom.domain.com/api/v3/projects/[project_id]/notices?key=[project_key]", true)
+      global.XMLHttpRequest.prototype.open.restore()


### PR DESCRIPTION
This will allow to use different software (like errbit) to work with airbrake-js
- Add host option to XHR and JSONP reporters and generate urls based on this options
- Add setHost method to Client class, which sets new custom host
- Add fetching custom host from data-airbrake-host attribute
- Add tests
