### PR TITLE
Leave global reference to notifier loader in case someone doesn't need it

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Alternatively you can set project id and API key using:
 
 Note that the above example reflects a typical setup in a project using jQuery, however jQuery is not a dependency for Airbrake-JS. Airbrake-JS has no dependencies.
 
+### Serving The Notifier By Yourself
+
+If you prefer to serve the main script (the notifier) yourself, you need to disable loading it from the CDN:
+
+    <script src="airbrake-shim.js"></script>
+    <script>
+        if (window.removeEventListener) {
+          window.removeEventListener('load', window.loadAirbrakeNotifier, false);
+        } else if (window.detachEvent) {
+          window.detachEvent('onload', window.loadAirbrakeNotifier);
+        }
+    </script>
+    <script src="airbrake.js"></script>
+
 ## Basic Usage
 
 The simplest method is to report errors directly:

--- a/airbrake-shim.coffee
+++ b/airbrake-shim.coffee
@@ -48,7 +48,7 @@ global.onerror = (message, file, line, column, error) ->
       columnNumber: column or 0,
     }})
 
-loadAirbrakeNotifier = ->
+global.loadAirbrakeNotifier = ->
   script = document.createElement('script')
   sibling = document.getElementsByTagName('script')[0]
   script.src = 'https://ssljscdn.airbrake.io/0.3/airbrake.min.js'
@@ -95,9 +95,9 @@ setupJQ = ->
 
 # Asynchronously loads global.Airbrake notifier.
 if global.addEventListener
-  global.addEventListener('load', loadAirbrakeNotifier, false)
+  global.addEventListener('load', global.loadAirbrakeNotifier, false)
 else if global.attachEvent
-  global.attachEvent('onload', loadAirbrakeNotifier)
+  global.attachEvent('onload', global.loadAirbrakeNotifier)
 
 # Reports exceptions thrown in jQuery event handlers.
 if global.jQuery


### PR DESCRIPTION
Hello :)

I work on a Rails project. I included both `airbrake-shim.js` and `airbrake.js` in my `aplication.js` (that is just a Sprockets manifest) and I don't need to load the main script asynchronously from CDN. I wanted to disable it but found out it was impossible because `removeEventListener` needs a reference to the listener and it exists only inside the IIFE.

What do you think about this solution?

Also, please let me know how to generate the .js file. I ran `coffee -c airbrake-shim.coffee` and then git showed me that almost the entire file was changed. I have CoffeeScript 1.8 installed. Thanks!