### PR TITLE
Better error message when notice can not be converted to JSON.

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -58,7 +58,7 @@ class Client
 
   push: (err) ->
     defContext = {
-      language: 'JavaScript'
+      language: 'JavaScript',
       sourceMapEnabled: true
     }
     if global.navigator?.userAgent

--- a/src/notifier.coffee
+++ b/src/notifier.coffee
@@ -1,4 +1,4 @@
-require("./util/compat.coffee")
+require('./util/compat.coffee')
 Client = require('./client.coffee')
 processor = require('./processors/stack.coffee')
 reporter = require('./reporters/hybrid.coffee')

--- a/src/util/jsonify_notice.coffee
+++ b/src/util/jsonify_notice.coffee
@@ -26,7 +26,11 @@ jsonifyNotice = (notice, n=1000, maxLength=64000) ->
       break
     n = Math.floor(n/2)
 
-  throw new Error("cannot jsonify notice (length=#{s.length} maxLength=#{maxLength})")
+  err = new Error("airbrake-js: cannot jsonify notice (length=#{s.length} maxLength=#{maxLength})")
+  err.params = {
+    json: s[..Math.floor(n/2)] + '...',
+  }
+  throw err
 
 
 module.exports = jsonifyNotice

--- a/test/unit/util/jsonify_notice_test.coffee
+++ b/test/unit/util/jsonify_notice_test.coffee
@@ -36,7 +36,6 @@ describe 'jsonify_notice', ->
       expect(json.length).to.be.below(maxLength)
 
   context 'when called with one huge string', ->
-    obj = null
     json = null
     maxLength = 30000
 
@@ -48,3 +47,25 @@ describe 'jsonify_notice', ->
 
     it 'limits json size', ->
       expect(json.length).to.be.below(maxLength)
+
+  context 'when called with huge error message', ->
+    fn = null
+    maxLength = 30000
+
+    beforeEach ->
+      obj = {
+        errors: [{
+          message: Array(100000).join('x')
+        }],
+      }
+      fn = ->
+        jsonifyNotice(obj, 1000, maxLength)
+
+    it 'throws an exception', ->
+      expect(fn).to.throw('airbrake-js: cannot jsonify notice (length=100068 maxLength=30000)')
+
+    it 'throws an exception with `json` property', ->
+      try
+        fn()
+      catch err
+        expect(err.params.json).to.be.defined

--- a/test/unit/util/truncate_test.coffee
+++ b/test/unit/util/truncate_test.coffee
@@ -115,3 +115,12 @@ describe 'truncate', ->
           }
         }
       })
+
+  context 'when called with n=0', ->
+    truncated = null
+
+    beforeEach ->
+      truncated = truncate({foo: 'bar'}, 0)
+
+    it 'produces [Truncated]', ->
+      expect(truncated).to.equal('[Truncated]')


### PR DESCRIPTION
Should help to debug https://github.com/airbrake/airbrake-js/issues/125