### PR TITLE
Use old compatibility API that does not require Content-Type header.

### DIFF
--- a/src/reporters/xhr.coffee
+++ b/src/reporters/xhr.coffee
@@ -2,15 +2,14 @@ jsonifyNotice = require('../internal/jsonify_notice')
 
 
 report = (notice, opts) ->
-  url = "#{opts.host}/api/v3/projects/#{opts.projectId}/notices?key=#{opts.projectKey}"
+  url = "#{opts.host}/api/v3/projects/#{opts.projectId}/create-notice?key=#{opts.projectKey}"
   payload = jsonifyNotice(notice)
 
   req = new global.XMLHttpRequest()
   req.open('POST', url, true)
-  req.setRequestHeader('Content-Type', 'application/json')
   req.send(payload)
   req.onreadystatechange = ->
-    if req.readyState == 4 and req.status == 201 and console?.debug?
+    if req.readyState == 4 and req.status == 200 and console?.debug?
       resp = JSON.parse(req.responseText)
       console.debug("airbrake: error #%s was reported: %s", resp.id, resp.url)
 

--- a/test/unit/reporters/xhr_test.coffee
+++ b/test/unit/reporters/xhr_test.coffee
@@ -22,11 +22,11 @@ describe "XhrReporter", ->
     it "opens async POST to url", ->
       spy = sinon.spy(global.XMLHttpRequest.prototype, 'open')
       reporter({}, {projectId: '[project_id]', projectKey: '[project_key]', host: 'https://api.airbrake.io'})
-      expect(spy).to.have.been.calledWith("POST", "https://api.airbrake.io/api/v3/projects/[project_id]/notices?key=[project_key]", true)
+      expect(spy).to.have.been.calledWith("POST", "https://api.airbrake.io/api/v3/projects/[project_id]/create-notice?key=[project_key]", true)
       global.XMLHttpRequest.prototype.open.restore()
 
     it "opens POST to custom url", ->
       spy = sinon.spy(global.XMLHttpRequest.prototype, 'open')
       reporter({}, {projectId: '[project_id]', projectKey: '[project_key]', host: 'https://custom.domain.com'})
-      expect(spy).to.have.been.calledWith("POST", "https://custom.domain.com/api/v3/projects/[project_id]/notices?key=[project_key]", true)
+      expect(spy).to.have.been.calledWith("POST", "https://custom.domain.com/api/v3/projects/[project_id]/create-notice?key=[project_key]", true)
       global.XMLHttpRequest.prototype.open.restore()


### PR DESCRIPTION
With this change browser should not issue CORS preflight request when
posting data to Airbrake.