### PR TITLE
Cleanup API to be consistent with other notifiers.

### DIFF
--- a/examples/browserify/app.js
+++ b/examples/browserify/app.js
@@ -9,7 +9,7 @@ if (window.jQuery) {
 try {
   throw new Error('hello from airbrake-js');
 } catch (err) {
-  promise = airbrake.push(err);
+  promise = airbrake.notify(err);
   promise.then(function(notice) {
     console.log("notice id", notice.id);
   });

--- a/examples/legacy/app.js
+++ b/examples/legacy/app.js
@@ -6,7 +6,7 @@ if (window.jQuery) {
 try {
   throw new Error('hello from airbrake-js');
 } catch (err) {
-  promise = airbrake.push(err);
+  promise = airbrake.notify(err);
   promise.then(function(notice) {
     console.log("notice id", notice.id);
   });

--- a/examples/requirejs/app.js
+++ b/examples/requirejs/app.js
@@ -14,7 +14,7 @@ require(['airbrakeJs/client', 'airbrakeJs/instrumentation/jquery'],
   try {
     throw new Error('hello from airbrake-js');
   } catch (err) {
-    promise = airbrake.push(err);
+    promise = airbrake.notify(err);
     promise.then(function(notice) {
       console.log("notice id", notice.id);
     });

--- a/test/unit/client_test.coffee
+++ b/test/unit/client_test.coffee
@@ -34,14 +34,14 @@ testWrap = (client) ->
       expect(wrapper.prop).to.equal("hello")
 
     it "reports throwed exception", ->
-      client.push = sinon.spy()
+      client.notify = sinon.spy()
       exc = new Error("test")
       fn = ->
         throw exc
       wrapper = client.wrap(fn)
       wrapper("hello", "world")
-      expect(client.push).to.have.been.called
-      expect(client.push.lastCall.args).to.deep.equal([{error: exc, params: {arguments: ["hello", "world"]}}])
+      expect(client.notify).to.have.been.called
+      expect(client.notify.lastCall.args).to.deep.equal([{error: exc, params: {arguments: ["hello", "world"]}}])
 
     it "wraps arguments", ->
       fn = sinon.spy()
@@ -74,32 +74,37 @@ describe "Client", ->
       promise.resolve({id: 1})
     client = new Client(processor: processor, reporter: reporter)
 
-  describe 'filters', ->
-    describe 'addFilter', ->
-      it 'can prevent report', ->
-        filter = sinon.spy((notice) -> false)
-        client.addFilter(filter)
+  describe 'filter', ->
+    it 'returns false to ignore notice', ->
+      filter = sinon.spy (notice) -> false
+      client.addFilter(filter)
 
-        client.push({})
-        continueFromProcessor = processor.lastCall.args[1]
-        continueFromProcessor('test', {})
+      client.notify({})
 
-        expect(reporter).not.to.have.been.called
-        expect(filter).to.have.been.called
+      expect(filter).to.have.been.called
+      expect(reporter).not.to.have.been.called
 
-      it 'can allow report', ->
-        filter = sinon.spy((notice) -> true)
-        client.addFilter(filter)
+    it 'returns true to pass notice', ->
+      filter = sinon.spy (notice) -> true
+      client.addFilter(filter)
 
-        client.push(error: {})
-        continueFromProcessor = processor.lastCall.args[1]
-        continueFromProcessor('test', {})
+      client.notify(error: {})
 
-        expect(reporter).to.have.been.called
-        notice = reporter.lastCall.args[0]
-        expect(filter).to.have.been.calledWith(notice)
+      expect(filter).to.have.been.called
+      expect(reporter).to.have.been.called
 
-  describe "push", ->
+    it 'returns notice to change payload', ->
+      filter = sinon.spy (notice) ->
+        notice.context.environment = 'production'
+      client.addFilter(filter)
+
+      client.notify(error: {})
+
+      expect(filter).to.have.been.called
+      notice = reporter.lastCall.args[0]
+      expect(notice.context.environment).to.equal('production')
+
+  describe "notify", ->
     exception = do ->
       error = undefined
       try
@@ -109,20 +114,20 @@ describe "Client", ->
       return error
 
     it "returns promise and resolves it", ->
-      promise = client.push(exception)
+      promise = client.notify(exception)
       onResolved = sinon.spy()
       promise.then(onResolved)
       expect(onResolved).to.have.been.called
 
     describe "with error", ->
       it "processor is called", ->
-        client.push(exception)
+        client.notify(exception)
 
         expect(processor).to.have.been.called
 
       it "reporter is called with valid options", ->
         client.setProject(999, "custom_project_key")
-        client.push(exception)
+        client.notify(exception)
 
         expect(reporter).to.have.been.called
         opts = reporter.lastCall.args[1]
@@ -134,7 +139,7 @@ describe "Client", ->
 
       it "reporter is called with custom host", ->
         client.setHost("https://custom.domain.com")
-        client.push(exception)
+        client.notify(exception)
 
         reported = reporter.lastCall.args[1]
         expect(reported.host).to.equal("https://custom.domain.com")
@@ -142,120 +147,120 @@ describe "Client", ->
     describe "custom data sent to reporter", ->
       it "reports context", ->
         client.addContext(context_key: "[custom_context]")
-        client.push(exception)
+        client.notify(exception)
 
         reported = reporter.lastCall.args[0]
         expect(reported.context.context_key).to.equal("[custom_context]")
 
       it "reports environment name", ->
         client.setEnvironmentName("[custom_env_name]")
-        client.push(exception)
+        client.notify(exception)
 
         reported = reporter.lastCall.args[0]
         expect(reported.context.environment).to.equal("[custom_env_name]")
 
       it "reports environment", ->
         client.addEnvironment(env_key: "[custom_env]")
-        client.push(exception)
+        client.notify(exception)
 
         reported = reporter.lastCall.args[0]
         expect(reported.environment.env_key).to.equal("[custom_env]")
 
       it "reports params", ->
         client.addParams(params_key: "[custom_params]")
-        client.push(exception)
+        client.notify(exception)
 
         reported = reporter.lastCall.args[0]
         expect(reported.params.params_key).to.equal("[custom_params]")
 
       it "reports session", ->
         client.addSession(session_key: "[custom_session]")
-        client.push(exception)
+        client.notify(exception)
 
         reported = reporter.lastCall.args[0]
         expect(reported.session.session_key).to.equal("[custom_session]")
 
       describe "wrapped error", ->
         it "unwraps and processes error", ->
-          client.push(error: exception)
+          client.notify(error: exception)
           expect(processor).to.have.been.calledWith(exception)
 
         it "reports custom context", ->
           client.addContext(context1: "value1", context2: "value2")
-          client.push
+          client.notify
             error: exception
             context:
-              context1: "push_value1"
-              context3: "push_value3"
+              context1: "notify_value1"
+              context3: "notify_value3"
 
           reported = reporter.lastCall.args[0]
           expect(reported.context).to.deep.equal
             language: "JavaScript"
             sourceMapEnabled: true
-            context1: "push_value1"
+            context1: "notify_value1"
             context2: "value2"
-            context3: "push_value3"
+            context3: "notify_value3"
 
         it "reports custom environment name", ->
           client.setEnvironmentName("env1")
-          client.push
+          client.notify
             error: exception
             context:
-              environment: "push_env1"
+              environment: "notify_env1"
 
           reported = reporter.lastCall.args[0]
           expect(reported.context).to.deep.equal
             language: "JavaScript"
             sourceMapEnabled: true
-            environment: "push_env1"
+            environment: "notify_env1"
 
         it "reports custom environment", ->
           client.addEnvironment(env1: "value1", env2: "value2")
-          client.push
+          client.notify
             error: exception
             environment:
-              env1: "push_value1"
-              env3: "push_value3"
+              env1: "notify_value1"
+              env3: "notify_value3"
 
           reported = reporter.lastCall.args[0]
           expect(reported.environment).to.deep.equal
-            env1: "push_value1"
+            env1: "notify_value1"
             env2: "value2"
-            env3: "push_value3"
+            env3: "notify_value3"
 
         it "reports custom params", ->
           client.addParams(param1: "value1", param2: "value2")
-          client.push
+          client.notify
             error: exception
             params:
-              param1: "push_value1"
-              param3: "push_value3"
+              param1: "notify_value1"
+              param3: "notify_value3"
 
           reported = reporter.lastCall.args[0]
           expect(reported.params).to.deep.equal
-            param1: "push_value1"
+            param1: "notify_value1"
             param2: "value2"
-            param3: "push_value3"
+            param3: "notify_value3"
 
         it "reports custom session", ->
           client.addSession(session1: "value1", session2: "value2")
-          client.push
+          client.notify
             error: exception
             session:
-              session1: "push_value1"
-              session3: "push_value3"
+              session1: "notify_value1"
+              session3: "notify_value3"
 
           reported = reporter.lastCall.args[0]
           expect(reported.session).to.deep.equal
-            session1: "push_value1"
+            session1: "notify_value1"
             session2: "value2"
-            session3: "push_value3"
+            session3: "notify_value3"
 
   describe "custom reporter", ->
     it "is called on error", ->
       custom_reporter = sinon.spy()
       client.addReporter(custom_reporter)
-      client.push(error: {})
+      client.notify(error: {})
       expect(custom_reporter).to.have.been.called
 
   testWrap(new Client(processor: null, reporter: null))


### PR DESCRIPTION
Changes:
- push is renamed to notify. push is still available, but is deprecated.
- setEnvironmentName, addContext, addEnvironment, addSession and addParams are deprecated in favor of filters.