### PR TITLE
Explicitly set content type to 'application/json'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+bower_components
 node_modules
 lib
+

--- a/dist/client.js
+++ b/dist/client.js
@@ -731,6 +731,7 @@ report = function(notice, opts, promise) {
   payload = jsonifyNotice(notice);
   req = new global.XMLHttpRequest();
   req.open('POST', url, true);
+  req.setRequestHeader('Content-Type', 'application/json');
   req.send(payload);
   return req.onreadystatechange = function() {
     var resp;

--- a/src/reporters/xhr.coffee
+++ b/src/reporters/xhr.coffee
@@ -7,6 +7,7 @@ report = (notice, opts, promise) ->
 
   req = new global.XMLHttpRequest()
   req.open('POST', url, true)
+  req.setRequestHeader('Content-Type', 'application/json');
   req.send(payload)
   req.onreadystatechange = ->
     if req.readyState == 4 and req.status == 200


### PR DESCRIPTION
The API mandates that JSON data be used, however the library sends the report method sends the payload with content type "text/html" or similar.

We have a constaint which only accepts traffic carrying the content type "application/json".
The notice is JSON-ified, so let's be explicit.

