### PR TITLE
Document CDN (cdnjs) usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ bower install airbrake-js-client
 
 ## Setup
 
-Notifier is built using [standalone browserify build](http://www.forbeslindesay.co.uk/post/46324645400/standalone-browserify-builds) and can be used with:
+The notifier is built using a
+[standalone browserify build](http://www.forbeslindesay.co.uk/post/46324645400/standalone-browserify-builds)
+and can be used with:
 - [RequireJS](examples/requirejs/app.js).
 - [Global/Window](examples/legacy/app.js).
 
-We also include full source code with the package, so you can use [Browserify](examples/browserify/app.js) too.
+We include the full source code with the package, so you can use
+[Browserify](examples/browserify/app.js) too.
+
+If you prefer not to host the library yourself,
+[airbrake-js is available on the excellent cdnjs CDN](https://cdnjs.com/libraries/airbrake-js).
 
 ## Basic Usage
 


### PR DESCRIPTION
Airbrake-js is now available on cdnjs:
https://cdnjs.com/libraries/airbrake-js

Fixes #151, #35.