### PR TITLE
add instructions for using with browserify/webpack/etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ First you need to initialize notifier with project id and API key taken from [Ai
 var airbrake = new airbrakeJs.Client({projectId: 1, projectKey: 'abc'});
 ```
 
+Or if you are using browserify/webpack/etc:
+
+```js
+var airbrakeJs = require('airbrake-js');
+var airbrake = new airbrakeJs({projectId: 1, projectKey: 'abc'});
+```
+
 The simplest method is to report errors directly:
 
 ```js


### PR DESCRIPTION
I am using webpack.  `airbrakeJs.Client` does not exist, but `new airbrakeJs(...)` works well.