### PR TITLE
package.json: depend on 'coffee-script' to fix builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "mocha": "^2.5.3",
     "requirejs": "^2.2.0",
     "sinon": "^1.17.4",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "coffee-script": "^1.11.0"
   },
   "main": "lib/client.js",
   "files": [


### PR DESCRIPTION
Otherwise it fails on Circle with:

```
Error: Cannot find module 'coffee-script/register'
```

It passes locally for me and I could see the
`node_modules/coffee-script` directory. However on Circle this
dependency is missing (not sure why).