### PR TITLE
Send errors to the /notices endpoint instead of /create-notice

### DIFF
--- a/src/reporters/compat.coffee
+++ b/src/reporters/compat.coffee
@@ -2,7 +2,7 @@ jsonifyNotice = require('../internal/jsonify_notice')
 
 
 report = (notice, opts, promise) ->
-  url = "#{opts.host}/api/v3/projects/#{opts.projectId}/create-notice?key=#{opts.projectKey}"
+  url = "#{opts.host}/api/v3/projects/#{opts.projectId}/notices?key=#{opts.projectKey}"
   payload = jsonifyNotice(notice)
 
   req = new global.XMLHttpRequest()

--- a/src/reporters/jsonp.coffee
+++ b/src/reporters/jsonp.coffee
@@ -16,7 +16,7 @@ report = (notice, opts, promise) ->
       global[cbName] = undefined
 
   payload = encodeURIComponent(jsonifyNotice(notice))
-  url = "#{opts.host}/api/v3/projects/#{opts.projectId}/create-notice?key=#{opts.projectKey}&callback=#{cbName}&body=#{payload}"
+  url = "#{opts.host}/api/v3/projects/#{opts.projectId}/notices?key=#{opts.projectKey}&callback=#{cbName}&body=#{payload}"
 
   document = global.document
   head = document.getElementsByTagName('head')[0]

--- a/test/unit/reporters/compat_test.coffee
+++ b/test/unit/reporters/compat_test.coffee
@@ -33,7 +33,7 @@ describe 'XhrReporter', ->
       })
       expect(spy).to.have.been.calledWith(
         'POST',
-        'https://api.airbrake.io/api/v3/projects/[project_id]/create-notice?key=[project_key]',
+        'https://api.airbrake.io/api/v3/projects/[project_id]/notices?key=[project_key]',
         true,
       )
 
@@ -46,6 +46,6 @@ describe 'XhrReporter', ->
       })
       expect(spy).to.have.been.calledWith(
         'POST',
-        'https://custom.domain.com/api/v3/projects/[project_id]/create-notice?key=[project_key]',
+        'https://custom.domain.com/api/v3/projects/[project_id]/notices?key=[project_key]',
         true,
       )


### PR DESCRIPTION
Fixes #213 (wrong url)
