### PR TITLE
Add banner plugin to show version info

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,8 @@ function newConfig() {
       new webpack.optimize.UglifyJsPlugin({
         include: /\.min\.js$/,
         sourceMap: true
-      })
+      }),
+      new webpack.BannerPlugin({banner: 'Airbrake JS v' + pkg.version})
     ]
   }
 };


### PR DESCRIPTION
Adds version info as a comment on build. Example: `/*! Airbrake JS v0.9.0 */` would be added as the first line of the files in `dist/`.