### PR TITLE
Update the angular 2 doc

### DIFF
--- a/examples/angular-2/README.md
+++ b/examples/angular-2/README.md
@@ -1,8 +1,11 @@
-# Usage with Angular 2 & TypeScript
+### Usage with Angular 2 & TypeScript
 
-Create `error_handler.ts`:
+### Create an error handler
+The first step is to create an error handler with an `AirbrakeClient`
+initialized with your `projectId` and `projectKey`. In this example the
+handler will be in a file called `error_handler.ts`.
 
-```TypeScript
+```ts
 import { ErrorHandler } from '@angular/core';
 import AirbrakeClient from 'airbrake-js';
 
@@ -22,9 +25,12 @@ export class AirbrakeErrorHandler implements ErrorHandler {
 }
 ```
 
-Add `ErrorHandler` provider to your `AppModule`:
+### Add the error handler to your `AppModule`
 
-```TypeScript
+The last step is adding the `ErrorHandler` to your `AppModule`, then your app
+will be ready to report errors to Airbrake.
+
+```ts
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule, ErrorHandler } from '@angular/core';
 
@@ -43,3 +49,4 @@ import { AirbrakeErrorHandler } from './error_handler';
 })
 export class AppModule { }
 ```
+


### PR DESCRIPTION
I plan to pull this README.md into airbrake-docs so we only need to manage the configuration for Angular 2 instructions in a single location.

I've made minor additions to the copy and modifications to header sizes to better fit into the docs site.

I updated the code blocks to use `ts` instead since the docs site does not perform correct highlighting with `TypeScript` specified.

More details: https://github.com/airbrake/airbrake-docs/pull/232