### PR TITLE
Update the React readme

### DIFF
--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -1,6 +1,8 @@
-# React error handler
+### React error handler
 
-You need to define `ErrorBoundary` component:
+To report errors from a React app, you'll need to set up and use an
+[`ErrorBoundary` component](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html)
+and initialize an `AirbrakeClient` with your `projectId` and `projectKey`.
 
 ```js
 import AirbrakeClient from 'airbrake-js';


### PR DESCRIPTION
I'm going to fetch this readme for use in airbrake-docs.
I've decreased the size of the header to better match what we use on the
docs site and added a bit more copy explaining the setup.