### PR TITLE
Adapt to typescript and esmodules

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,19 @@
     "webpack-cli": "^2.0.14"
   },
   "main": "dist/client.js",
+  "module": "esm/src/client.js",
+  "typings": "dist/src/client.d.ts",
   "files": [
     "dist/",
+    "esm/",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
     "build": "webpack",
+    "build:dts": "tsc -p ./tsconfig.json --declaration --emitDeclarationOnly --ourDir ./dist",
+    "build:esm": "tsc -p ./tsconfig.json --target ES6 --module commonjs --outDir ./esm",
+    "prepublishOnly": "npm run build:dts && npm run build:esm",
     "test": "karma start"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "lib": ["ES2015", "DOM"],
-        "target": "ES5",
+        "target": "ES6",
         "moduleResolution": "node",
         "strictNullChecks": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
- Using with typescript, type declaration is missing. So I fixed to build `d.ts` when prepublish.
- Using with webpack, many project provides es6 sources. So I fixed to build es6 sources when prepublish.
    - Notes: Unfortunately, now airbrake-js is using TypeScript-specific module resolution as `export`. This should be fixed to use ES Modules.