### PR TITLE
Handle native or bluebird Promise rejections

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -262,12 +262,16 @@ class Client {
         this.offline = true;
     }
 
-    private onUnhandledrejection(e: PromiseRejectionEvent): void {
-        let msg = e.reason.message || String(e.reason);
+    private onUnhandledrejection(e: PromiseRejectionEvent | CustomEvent): void {
+        // Handle native or bluebird Promise rejections
+        // https://developer.mozilla.org/en-US/docs/Web/Events/unhandledrejection
+        // http://bluebirdjs.com/docs/api/error-management-configuration.html
+        let reason = (<PromiseRejectionEvent>e).reason || (<CustomEvent>e).detail.reason;
+        let msg = reason.message || String(reason);
         if (msg.indexOf && msg.indexOf('airbrake: ') === 0) {
             return;
         }
-        this.notify(e.reason);
+        this.notify(reason);
     }
 }
 


### PR DESCRIPTION
The native event-handler in Chrome puts the Reason and Promise in the root event, but Bluebird attaches them to the event detail.

https://developer.mozilla.org/en-US/docs/Web/Events/unhandledrejection
http://bluebirdjs.com/docs/api/error-management-configuration.html