### PR TITLE
Fix nodejs example

### DIFF
--- a/examples/nodejs/app.js
+++ b/examples/nodejs/app.js
@@ -1,4 +1,5 @@
 var http = require('http');
+// make sure `request` package is installed before using airbrake-js
 var AirbrakeClient = require('airbrake-js');
 
 http.createServer(function (req, res) {


### PR DESCRIPTION
Hi, without this fix we catch an error:
`error TypeError: requestWrapper is not a function`
in node_modules/airbrake-js/dist/client.js:2530:9