### PR TITLE
Fix error message in target path when className not a string

### DIFF
--- a/src/instrumentation/dom.ts
+++ b/src/instrumentation/dom.ts
@@ -20,7 +20,7 @@ function elemName(elem: HTMLElement): string {
         s.push(elem.id);
     }
 
-    if (elem.className) {
+    if (typeof elem.className === 'string') {
         s.push('.');
         s.push(elem.className.split(' ').join('.'));
     }


### PR DESCRIPTION
This PR fixes an error in airbrake breadcrumb element path

Example error: `Click on<TypeError: e.className.split is not a function>`
<img width="586" alt="screen shot 2018-10-04 at 11 44 38" src="https://user-images.githubusercontent.com/1933404/46466206-f145ba00-c7ca-11e8-8d50-1170d3ac5495.png">

The root cause of this issue is because not all `className` property of DOM elements are strings. Those who don't have no `split` method (for example, `svg` element and their children, with type `SVGAnimatedString` instead of `string`).

You can see all element with issue in a page using the following snippet: `Array.from(document.body.getElementsByTagName("*")).filter(elm => elm.className).filter(elm => typeof elm.className !== 'string')`

