### PR TITLE
Fix handling unhandled rejections without reasons

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -301,7 +301,7 @@ class Client {
         // Handle native or bluebird Promise rejections
         // https://developer.mozilla.org/en-US/docs/Web/Events/unhandledrejection
         // http://bluebirdjs.com/docs/api/error-management-configuration.html
-        let reason = (<PromiseRejectionEvent>e).reason || (<CustomEvent>e).detail.reason;
+        let reason = (<PromiseRejectionEvent>e).reason || (<CustomEvent>e).detail && (<CustomEvent>e).detail.reason || 'unhandled rejection with no reason given';
         let msg = reason.message || String(reason);
         if (msg.indexOf && msg.indexOf('airbrake: ') === 0) {
             return;

--- a/test/unit/client_test.ts
+++ b/test/unit/client_test.ts
@@ -629,6 +629,17 @@ describe('Client', () => {
             }, 0);
         });
 
+        it('notifies about rejections with no reason', (done) => {
+            new Promise((_resolve, reject) => {
+                reject();
+            });
+
+            setTimeout(() => {
+                expect(reporter).to.have.been.called;
+                done();
+            }, 0);
+        });
+
         it('notifies about errors thrown in Promise.catch', (done) => {
             let p = new Promise((_, reject) => {
                 setTimeout(() => {


### PR DESCRIPTION
If no reason is specified in the rejection, the client would throw
`Error: Uncaught TypeError: Cannot read property 'reason' of undefined`.
This adds a guard to reading the `.detail` property.

We are seeing this error a lot in our airbrake logs, which is how we caught this :)