### PR TITLE
Fix hasOwnProperty for non-Object-prototyped objects

### DIFF
--- a/src/jsonify_notice.ts
+++ b/src/jsonify_notice.ts
@@ -186,7 +186,7 @@ class Truncator {
         let length = 0;
         let dst = {};
         for (let key in obj) {
-            if (!obj.hasOwnProperty(key)) {
+            if (!Object.prototype.hasOwnProperty.call(obj, key)) {
                 continue;
             }
             if (isBlacklisted(key, this.keysBlacklist)) {

--- a/test/unit/truncate_test.ts
+++ b/test/unit/truncate_test.ts
@@ -136,6 +136,14 @@ describe('truncate', () => {
         });
     });
 
+    context('when called with object created with Object.create(null)', () => {
+        it('works', () => {
+            let obj: any = Object.create(null);
+            obj.foo = 'bar';
+            expect(truncate(obj)).to.deep.equal({ foo: 'bar' });
+        });
+    });
+
     describe('keysBlacklist', () => {
         it('filters blacklisted keys', () => {
             let obj = {


### PR DESCRIPTION
airbrake-js version: 1.6.2
node version: 10.3
express version: 4.16.3

This PR fixes a 'TypeError: obj.hasOwnProperty is not a function' error in `src/jsonify_notice.ts`. 

express-js creates its body params with `Object.create(null)` ([here i think](https://github.com/expressjs/multer/blob/47b0a1b1e19ed142fb4cd4a2053fe37f36f528ab/lib/make-middleware.js#L28). This means they don't have the `hasOwnProperty` function, as that comes from the Object prototype.