### PR TITLE
fixed <TypeError: Object doesn't support property or method 'from'>

### DIFF
--- a/src/instrumentation/dom.ts
+++ b/src/instrumentation/dom.ts
@@ -18,7 +18,7 @@ function elemName(elem: HTMLElement): string {
     s.push(elem.id);
   }
 
-  if (elem.classList) {
+  if (elem.classList && Array.from) {
     s.push('.');
     s.push(Array.from(elem.classList).join('.'));
   } else if (elem.className) {


### PR DESCRIPTION
On older browsers and IE11 `Array.from` does not exist and causes an error.