### PR TITLE
Clarify AngularJS vs Angular example apps

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -43,8 +43,8 @@ Your package manager should automatically pick suitable bundle format based on @
 
 Example configurations can be found in [examples](examples), including:
 
-* [Angular](examples/angular)
-* [Angular 2](examples/angular-2)
+* [AngularJS](examples/angular)
+* [Angular 2+](examples/angular-2)
 * [Browserify](examples/browserify)
 * [Legacy](examples/legacy)
 * [Rails](examples/rails)

--- a/packages/browser/examples/angular-2/README.md
+++ b/packages/browser/examples/angular-2/README.md
@@ -1,4 +1,4 @@
-### Usage with Angular 2 & TypeScript
+### Usage with Angular 2+ & TypeScript
 
 ### Create an error handler
 The first step is to create an error handler with a `Notifier`

--- a/packages/browser/examples/angular/README.md
+++ b/packages/browser/examples/angular/README.md
@@ -1,4 +1,4 @@
-# Usage with Angular
+# Usage with AngularJS
 
 Integration with Angular is as simple as adding an
 [$exceptionHandler](https://docs.angularjs.org/api/ng/service/$exceptionHandler):


### PR DESCRIPTION
Clarify which example is AngularJS (AKA: Angular version 1) and which example is Angular (AKA: Angular version 2 and up).