### PR TITLE
Fix AngularJS Example Typo in README.md

### DIFF
--- a/packages/browser/examples/angular/README.md
+++ b/packages/browser/examples/angular/README.md
@@ -8,8 +8,8 @@ angular
   .module('app')
   .factory('$exceptionHandler', function ($log) {
     var airbrake = new Notifier({
-      projectid: 1,       // Airbrake project id
-      projectkey: 'FIXME' // Airbrake project API key
+      projectId: 1,       // Airbrake project id
+      projectKey: 'FIXME' // Airbrake project API key
     });
 
     airbrake.addFilter(function (notice) {


### PR DESCRIPTION
The example given for `Angularjs` had a case-sensitivity typo that occurred to me while checking the library with my application.
The correct names for the params are `projectId` and `projectKey`.