### PR TITLE
Fix import statement

### DIFF
--- a/packages/browser/examples/react/README.md
+++ b/packages/browser/examples/react/README.md
@@ -5,7 +5,7 @@ To report errors from a React app, you'll need to set up and use an
 and initialize an `Airbrake.Notifier` with your `projectId` and `projectKey`.
 
 ```js
-import { Notifier } from '@airbrake/notifier';
+import { Notifier } from '@airbrake/browser';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {


### PR DESCRIPTION
The library is `@airbrake/browser` not `@airbrake/notifier`.  This was reported by a user via support.