### PR TITLE
Fix stacktrace test for node v10

### DIFF
--- a/packages/browser/tests/processor/stacktracejs.test.js
+++ b/packages/browser/tests/processor/stacktracejs.test.js
@@ -5,12 +5,16 @@ describe('stacktracejs processor', () => {
   let error;
 
   describe('Error', () => {
-    beforeEach(() => {
+    function throwTestError() {
       try {
         throw new Error('BOOM');
       } catch (err) {
         error = espProcessor(err);
       }
+    }
+
+    beforeEach(() => {
+      throwTestError();
     });
 
     it('provides type and message', () => {
@@ -24,7 +28,7 @@ describe('stacktracejs processor', () => {
 
       let frame = backtrace[0];
       expect(frame.file).toContain('tests/processor/stacktracejs.test');
-      expect(frame.function).toBe('Object.<anonymous>');
+      expect(frame.function).toBe('throwTestError');
       expect(frame.line).toEqual(expect.any(Number));
       expect(frame.column).toEqual(expect.any(Number));
     });


### PR DESCRIPTION
Node.js v10 is returning the function name as `'Object.beforeEach'` rather than `'Object.<anonymous>'`. By moving the code that throws the error out of an anonymous function and into a named function, we can avoid this ambiguity.