### PR TITLE
Update React installation instructions

### DIFF
--- a/packages/browser/examples/react/README.md
+++ b/packages/browser/examples/react/README.md
@@ -2,7 +2,7 @@
 
 To report errors from a React app, you'll need to set up and use an
 [`ErrorBoundary` component](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html)
-and initialize an `Airbrake.Notifier` with your `projectId` and `projectKey`.
+and initialize a `Notifier` with your `projectId` and `projectKey`.
 
 ```js
 import { Notifier } from '@airbrake/browser';


### PR DESCRIPTION
We are using `Notifier` instead of `Airbrake.Notifier` since
https://github.com/airbrake/airbrake-js/commit/7f01da95503fc0157299e52e7d34b98956361b5f#diff-e859334626963a0e732c1606a9531dd6.