### PR TITLE
Fix import of INotice

### DIFF
--- a/packages/browser/src/filter/filter.ts
+++ b/packages/browser/src/filter/filter.ts
@@ -1,3 +1,3 @@
-import INotice from '../notice';
+import { INotice } from '../notice';
 
 export type Filter = (notice: INotice) => INotice | null;


### PR DESCRIPTION
Fixes this error:

```
Module '"/airbrake-js/packages/browser/src/notice"' has no default export. Did you mean to use 'import { INotice } from "/airbrake-js/packages/browser/src/notice"' instead?
```