### PR TITLE
Add config option to disable performance stats

### DIFF
--- a/packages/browser/dist/airbrake.d.ts
+++ b/packages/browser/dist/airbrake.d.ts
@@ -35,6 +35,7 @@ export interface IOptions {
   timeout?: number;
   keysBlacklist?: any[];
   instrumentation?: IInstrumentationOptions;
+  performanceStats?: boolean;
 }
 
 interface IFuncWrapper {

--- a/packages/browser/src/options.ts
+++ b/packages/browser/src/options.ts
@@ -24,6 +24,7 @@ export interface IOptions {
   processor?: Processor;
   reporter?: Reporter;
   instrumentation?: IInstrumentationOptions;
+  performanceStats?: boolean;
 
   request?: request.RequestAPI<
     request.Request,

--- a/packages/node/src/notifier.ts
+++ b/packages/node/src/notifier.ts
@@ -14,6 +14,7 @@ export class Notifier extends BaseNotifier {
     if (!opt.environment && process.env.NODE_ENV) {
       opt.environment = process.env.NODE_ENV;
     }
+    opt.performanceStats = opt.performanceStats !== false;
     super(opt);
 
     this.addFilter(nodeFilter);
@@ -53,7 +54,9 @@ export class Notifier extends BaseNotifier {
       });
     });
 
-    this._instrument();
+    if (opt.performanceStats) {
+      this._instrument();
+    }
   }
 
   scope(): Scope {

--- a/packages/node/tests/notifier.test.js
+++ b/packages/node/tests/notifier.test.js
@@ -1,0 +1,43 @@
+import { Notifier } from '../src/notifier';
+
+describe('Notifier', () => {
+  describe('configuration', () => {
+    describe('performanceStats', () => {
+      test('is enabled by default', () => {
+        const notifier = new Notifier({
+          projectId: 1,
+          projectKey: 'key',
+        });
+        expect(notifier._opt.performanceStats).toEqual(true);
+      });
+
+      test('sets up instrumentation when enabled', () => {
+        Notifier.prototype._instrument = jest.fn();
+        const notifier = new Notifier({
+          projectId: 1,
+          projectKey: 'key',
+        });
+        expect(notifier._instrument.mock.calls.length).toEqual(1);
+      });
+
+      test('can be disabled', () => {
+        const notifier = new Notifier({
+          projectId: 1,
+          projectKey: 'key',
+          performanceStats: false,
+        });
+        expect(notifier._opt.performanceStats).toEqual(false);
+      });
+
+      test('does not set up instrumentation when disabled', () => {
+        Notifier.prototype._instrument = jest.fn();
+        const notifier = new Notifier({
+          projectId: 1,
+          projectKey: 'key',
+          performanceStats: false,
+        });
+        expect(notifier._instrument.mock.calls.length).toEqual(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Allows users to disable the automatic instrumentation of various performance stats.

For https://github.com/airbrake/airbrake-js/issues/641