### PR TITLE
browser: add tslib to devDependencies

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -36,6 +36,7 @@
     "rollup": "^2.6.1",
     "rollup-plugin-terser": "^5.3.0",
     "ts-jest": "^25.3.0",
+    "tslib": "^1.11.1",
     "tslint": "^6.1.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7479,7 +7479,7 @@ ts-jest@^25.3.0:
     semver "6.x"
     yargs-parser "18.x"
 
-tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.11.1, tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
tslib is a peer dependency of @rollup/plugin-typescript.