### PR TITLE
Add script for CI test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
       - run: yarn install
       - run: yarn lint
       - run: yarn build
-      - run: yarn test
+      - run: yarn test:ci

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:watch": "lerna run build:watch --parallel",
     "clean": "lerna run clean",
     "lint": "lerna run lint",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "test:ci": "lerna run test:ci"
   },
   "workspaces": ["packages/*"]
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -63,6 +63,7 @@
     "build:umd": "rollup --config",
     "clean": "rm -rf dist esm umd",
     "lint": "tslint -p .",
-    "test": "jest"
+    "test": "jest",
+    "test:ci": "jest --runInBand"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -51,6 +51,7 @@
     "build:esm:watch": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
     "clean": "rm -rf dist esm",
     "lint": "tslint -p .",
-    "test": "jest"
+    "test": "jest",
+    "test:ci": "jest --runInBand"
   }
 }


### PR DESCRIPTION
Makes use of `runInBand` option, which is recommended to use in situations with limited resources.
https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server

Fixes #663 