### PR TITLE
browser: add guard for window being undefined

### DIFF
--- a/packages/browser/src/notifier.ts
+++ b/packages/browser/src/notifier.ts
@@ -25,6 +25,10 @@ export class Notifier extends BaseNotifier {
   constructor(opt: IOptions) {
     super(opt);
 
+    if (typeof window === 'undefined') {
+      return;
+    }
+
     this.addFilter(windowFilter);
 
     if (window.addEventListener) {


### PR DESCRIPTION
When the notifier is loaded via server-side rendering, we need to return early because `window` is not available.

Fixes https://github.com/airbrake/airbrake-js/issues/678