### PR TITLE
Add import and export for React example

### DIFF
--- a/packages/browser/examples/react/README.md
+++ b/packages/browser/examples/react/README.md
@@ -5,6 +5,7 @@ To report errors from a React app, you'll need to set up and use an
 and initialize a `Notifier` with your `projectId` and `projectKey`.
 
 ```js
+import React, { Component } from 'react';
 import { Notifier } from '@airbrake/browser';
 
 class ErrorBoundary extends React.Component {
@@ -35,6 +36,8 @@ class ErrorBoundary extends React.Component {
     return this.props.children;
   }
 }
+
+export default ErrorBoundary;
 ```
 
 Then you can use it as a regular component:


### PR DESCRIPTION
The general React library which is needed in this example. To use this example in your app, you also need to export the newly added component. This update adds those two to make the example easier to follow.