### PR TITLE
Use req.originalUrl instead of req.path

### DIFF
--- a/packages/node/src/instrumentation/express.ts
+++ b/packages/node/src/instrumentation/express.ts
@@ -24,7 +24,7 @@ export function makeMiddleware(airbrake: Notifier) {
 
 export function makeErrorHandler(airbrake: Notifier) {
   return function airbrakeErrorHandler(err: Error, req, _res, next): void {
-    const url = req.protocol + '://' + req.headers.host + req.path;
+    const url = req.protocol + '://' + req.headers.host + req.originalUrl;
     const notice: any = {
       error: err,
       context: {


### PR DESCRIPTION
When reporting the current URL, we should use `originalUrl` over `path`. `path` does not include the mount point while `originalUrl` does.

https://expressjs.com/en/4x/api.html#req.path
https://expressjs.com/en/4x/api.html#req.originalUrl