### PR TITLE
Add performance filtering

### DIFF
--- a/packages/browser/src/filter/performance_filter.ts
+++ b/packages/browser/src/filter/performance_filter.ts
@@ -1,0 +1,3 @@
+import { RouteMetric } from '../routes';
+
+export type PerformanceFilter = (metric: RouteMetric) => RouteMetric | null;

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -209,3 +209,17 @@ const airbrake = new Notifier({
   performanceStats: false
 });
 ```
+
+### Filtering performance data
+`addPerformanceFilter` allows for filtering performance data. Return `null` in
+the filter to prevent that metric from being reported to Airbrake.
+
+```js
+airbrake.addPerformanceFilter((metric) => {
+  if (metric.route === '/foo') {
+    // Requests to '/foo' will not be reported
+    return null;
+  }
+  return metric;
+});
+```

--- a/packages/node/tests/routes.test.js
+++ b/packages/node/tests/routes.test.js
@@ -1,20 +1,25 @@
 import { Notifier } from '../src/notifier';
 
 describe('Routes', () => {
-  it('works', () => {
-    const opt = {
-      projectId: 1,
-      projectKey: 'test',
-    };
-    const notifier = new Notifier(opt);
-    const routes = notifier.routes;
+  const opt = {
+    projectId: 1,
+    projectKey: 'test',
+  };
+  let notifier;
+  let routes;
+  let req;
 
-    let req = routes.start('GET', '/projects/:id');
+  beforeEach(() => {
+    notifier = new Notifier(opt);
+    routes = notifier.routes;
+    req = routes.start('GET', '/projects/:id');
     req.statusCode = 200;
     req.contentType = 'application/json';
     req.startTime = new Date(1);
     req.endTime = new Date(1000);
+  });
 
+  it('collects metrics to report to Airbrake', () => {
     routes.notify(req);
     clearTimeout(routes._routes._timer);
     clearTimeout(routes._breakdowns._timer);
@@ -28,5 +33,14 @@ describe('Routes', () => {
         tdigestCentroids: { count: [1], mean: [999] },
       },
     });
+  });
+
+  it('does not collect metrics that are filtered', () => {
+    notifier.addPerformanceFilter(() => null);
+    routes.notify(req);
+    clearTimeout(routes._routes._timer);
+    clearTimeout(routes._breakdowns._timer);
+
+    expect(routes._routes._m).toStrictEqual({});
   });
 });


### PR DESCRIPTION
Allows users to stop metrics from being reported to Airbrake.

Closes https://github.com/airbrake/airbrake-js/issues/688