### PR TITLE
Add unhandledRejection info to context

### DIFF
--- a/packages/browser/src/notifier.ts
+++ b/packages/browser/src/notifier.ts
@@ -145,6 +145,7 @@ export class Notifier extends BaseNotifier {
           unhandledRejection: true,
         },
       });
+      return;
     }
     this.notify({
       ...err,

--- a/packages/browser/src/notifier.ts
+++ b/packages/browser/src/notifier.ts
@@ -138,9 +138,9 @@ export class Notifier extends BaseNotifier {
     if (msg.indexOf && msg.indexOf('airbrake: ') === 0) {
       return;
     }
-    if (typeof err !== 'object' || err.error === undefined) {
+    if (typeof reason !== 'object' || reason.error === undefined) {
       this.notify({
-        error: err,
+        error: reason,
         context: {
           unhandledRejection: true,
         },
@@ -148,7 +148,7 @@ export class Notifier extends BaseNotifier {
       return;
     }
     this.notify({
-      ...err,
+      ...reason,
       context: {
         unhandledRejection: true,
       },

--- a/packages/browser/src/notifier.ts
+++ b/packages/browser/src/notifier.ts
@@ -138,7 +138,20 @@ export class Notifier extends BaseNotifier {
     if (msg.indexOf && msg.indexOf('airbrake: ') === 0) {
       return;
     }
-    this.notify(reason);
+    if (typeof err !== 'object' || err.error === undefined) {
+      this.notify({
+        error: err,
+        context: {
+          unhandledRejection: true,
+        },
+      });
+    }
+    this.notify({
+      ...err,
+      context: {
+        unhandledRejection: true,
+      },
+    });
   }
 
   onerror(


### PR DESCRIPTION
To distinguish error source, I wanna add `context` information when error was caught by `unhandledrejection` event.
It's similar as errors from `window.onerror` have `windowError` context as below:

https://github.com/airbrake/airbrake-js/blob/ec02287618015aa318493cc7de196a5738cb5a41/packages/browser/src/notifier.ts#L144-L182

---

In the case of `unhandledrejection`, the parameter of `notify` method can be either object or other types.
https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent/reason

`base_notifier` checks it here:
https://github.com/airbrake/airbrake-js/blob/ec02287618015aa318493cc7de196a5738cb5a41/packages/browser/src/base_notifier.ts#L114-L116

So I added this check in advance before calling `notify` method. (Though there may be more good way)

I hope this pull request to be merged, thank you!
