### PR TITLE
Add new logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://airbrake-github-assets.s3.amazonaws.com/brand/airbrake-full-logo.png" width="200">
+</p>
+
 # Official Airbrake Notifiers for JavaScript
 
 [![Build Status](https://github.com/airbrake/airbrake-js/workflows/CI/badge.svg?branch=master)](https://github.com/airbrake/airbrake-js/actions?query=branch%3Amaster)

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://airbrake-github-assets.s3.amazonaws.com/brand/airbrake-full-logo.png" width="200">
+</p>
+
 # Official Airbrake Notifier for Browsers
 
 [![Build Status](https://github.com/airbrake/airbrake-js/workflows/CI/badge.svg?branch=master)](https://github.com/airbrake/airbrake-js/actions?query=branch%3Amaster)
@@ -7,8 +11,6 @@ The official Airbrake notifier for capturing JavaScript errors in web browsers
 and reporting them to [Airbrake](http://airbrake.io). If you're looking for
 Node.js support, there is a
 [separate package](https://github.com/airbrake/airbrake-js/tree/master/packages/node).
-
-![Airbrake Arthur JS](https://camo.githubusercontent.com/1a7883d5943fa246a1383723ef51e4e821eca32f/687474703a2f2f662e636c2e6c792f6974656d732f34343345324a31443257337831453175336a31752f4a532d6169726272616b656d616e2e6a7067)
 
 ## Installation
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://airbrake-github-assets.s3.amazonaws.com/brand/airbrake-full-logo.png" width="200">
+</p>
+
 # Official Airbrake Notifier for Node.js
 
 [![Build Status](https://github.com/airbrake/airbrake-js/workflows/CI/badge.svg?branch=master)](https://github.com/airbrake/airbrake-js/actions?query=branch%3Amaster)
@@ -7,8 +11,6 @@ The official Airbrake notifier for capturing JavaScript errors in Node.js and
 reporting them to [Airbrake](http://airbrake.io). If you're looking for
 browser support, there is a
 [separate package](https://github.com/airbrake/airbrake-js/tree/master/packages/browser).
-
-![Airbrake Arthur Node](https://camo.githubusercontent.com/9b7c0aad92f9dd2eb03b4dafd2e53784a2199216/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6169726272616b652d6769746875622d6173736574732f6e6f64652d6169726272616b652f6172746875722d6e6f64652e6a706567)
 
 ## Installation
 


### PR DESCRIPTION
Airbrake has a new logo. This replaces the old Arthur logos (which looked to be a broken link) with this new logo:

<img src="https://airbrake-github-assets.s3.amazonaws.com/brand/airbrake-full-logo.png" width="200">