### PR TITLE
Remove deprecated `keysBlacklist` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 
-- [browser] Removed deprecated `ignoreWindowError` option
+- [browser/node] Removed deprecated `ignoreWindowError` option
   ([#929](https://github.com/airbrake/airbrake-js/pull/929))
+- [browser/node] Removed deprecated `keysBlacklist` option
+  ([#930](https://github.com/airbrake/airbrake-js/pull/930))
 
 ## [1.4.2] - 2020-12-22
 ### Changed

--- a/packages/browser/src/base_notifier.ts
+++ b/packages/browser/src/base_notifier.ts
@@ -47,8 +47,7 @@ export class BaseNotifier {
     this._opt = opt;
     this._opt.host = this._opt.host || 'https://api.airbrake.io';
     this._opt.timeout = this._opt.timeout || 10000;
-    this._opt.keysBlocklist = this._opt.keysBlocklist ||
-      this._opt.keysBlacklist || [/password/, /secret/];
+    this._opt.keysBlocklist = this._opt.keysBlocklist || [/password/, /secret/];
     this._url = `${this._opt.host}/api/v3/projects/${this._opt.projectId}/notices?key=${this._opt.projectKey}`;
 
     this._processor = this._opt.processor || espProcessor;

--- a/packages/browser/src/options.ts
+++ b/packages/browser/src/options.ts
@@ -20,10 +20,6 @@ export interface IOptions {
   host?: string;
   timeout?: number;
   keysBlocklist?: any[];
-  /**
-   * @deprecated use keysBlocklist
-   */
-  keysBlacklist?: any[];
   processor?: Processor;
   reporter?: Reporter;
   instrumentation?: IInstrumentationOptions;


### PR DESCRIPTION
Deprecated in 037352ac3a415a9dd3b6c1b30af916535d5eab12.

It's time to remove it.