### PR TITLE
remote_settings: fix TypeError when calling Object.entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+- [browser] Fixed `TypeError: undefined is not an object (evaluating
+  'e.searchParams.append')` occurring in old browsers that don't support
+  `Object.entries` (such as Internet Explorer)
+  ([#1001](https://github.com/airbrake/airbrake-js/pull/1001))
+
 ## [2.1.3] - 2021-02-22
 
 - [browser/node] Fixed missing library files in v2.1.2

--- a/packages/browser/src/remote_settings.ts
+++ b/packages/browser/src/remote_settings.ts
@@ -38,6 +38,10 @@ interface IRemoteConfigSetting {
   endpoint: string;
 }
 
+type Entries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];
+
 export class RemoteSettings {
   _opt: IOptions;
   _requester: Requester;
@@ -103,7 +107,7 @@ export class RemoteSettings {
   _pollUrl(opt: IOptions): string {
     const url = new URL(this._data.configRoute(opt.remoteConfigHost));
 
-    for (const [key, value] of Object.entries(NOTIFIER_INFO)) {
+    for (const [key, value] of this._entries(NOTIFIER_INFO)) {
       url.searchParams.append(key, value);
     }
 
@@ -122,6 +126,18 @@ export class RemoteSettings {
       return;
     }
     this._opt.performanceStats = data.performanceStats();
+  }
+
+  // Polyfill from:
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#polyfill
+  _entries<T>(obj: T): Entries<T> {
+    const ownProps = Object.keys(obj);
+    let i = ownProps.length;
+    const resArray = new Array(i);
+
+    while (i--) resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+    return resArray;
   }
 }
 


### PR DESCRIPTION
Fixes #1000
(TypeError: undefined is not an object (evaluating 'e.searchParams.append'))

Old browsers such as IE don't support `Object.entries`. Therefore, all the calls
to that property would fail... every 10 minutes :-(

`Object.entries` support:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#browser_compatibility