### PR TITLE
browser/src/routes: correctly index last element in responseType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- [browser] Fixed not being able to attach a response type when sending a
+  performance breakdown
+  ([#1128](https://github.com/airbrake/airbrake-js/pull/1128))
+
 ## [2.1.5] - 2021-06-02
 - [node] Specify which versions of node are supported
   ([#1038](https://github.com/airbrake/airbrake-js/pull/1038))

--- a/packages/browser/src/routes.ts
+++ b/packages/browser/src/routes.ts
@@ -244,6 +244,7 @@ export class RoutesBreakdowns {
     if (!req.contentType) {
       return '';
     }
-    return req.contentType.split(';')[0].split('/')[-1];
+    const s = req.contentType.split(';')[0].split('/');
+    return s[s.length - 1];
   }
 }


### PR DESCRIPTION
In JavaScript we cannot reference array elements by providing a negative
index (unlike in Ruby or Python). The code incorrectly assumed that this works.
As result, the library could never send any response types to Airbrake.

The fix is simple: we reference the last element of the array the way JavaScript
wants.