### PR TITLE
notifier: do not use relative import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- [browser] Fixed relative import issues with Yarn's Plug'n'Play feature
+  ([#1135](https://github.com/airbrake/airbrake-js/pull/1135))
+
 ## [2.1.7] - 2021-10-04
 - [browser/node] Fixed incorrect `yarn.lock` references
   ([#1132](https://github.com/airbrake/airbrake-js/pull/1132))

--- a/packages/node/src/notifier.ts
+++ b/packages/node/src/notifier.ts
@@ -1,5 +1,4 @@
-// import { BaseNotifier, INotice, IOptions } from '@airbrake/browser';
-import { BaseNotifier, INotice, IOptions } from '../../browser';
+import { BaseNotifier, INotice, IOptions } from '@airbrake/browser';
 import { nodeFilter } from './filter/node';
 import { Scope, ScopeManager } from './scope';
 


### PR DESCRIPTION
Fixes #1104 (Relative import breaks Yarn Berry Plug'n'Play)

I must've left this by accident.