### PR TITLE
Bump cross-fetch from 3.0.5 to 3.1.5

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/promise-polyfill": "^6.0.3",
     "@types/request": "2.48.8",
-    "cross-fetch": "^3.0.4",
+    "cross-fetch": "^3.1.5",
     "error-stack-parser": "^2.0.4",
     "promise-polyfill": "^8.1.3",
     "tdigest": "^0.1.1"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@airbrake/browser": "^2.1.7",
-    "cross-fetch": "^3.0.4",
+    "cross-fetch": "^3.1.5",
     "error-stack-parser": "^2.0.4",
     "tdigest": "^0.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3365,7 +3365,7 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cross-fetch@^3.0.4:
+cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake-js/issues/1264
(security update: cross-fetch)