### PR TITLE
package.json: don't pass clearCache to Jest

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -63,6 +63,6 @@
     "build:umd": "rollup --config",
     "clean": "rm -rf dist esm umd",
     "lint": "tslint -p .",
-    "test": "jest --clearCache"
+    "test": "jest"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -54,6 +54,6 @@
     "build:esm:watch": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
     "clean": "rm -rf dist esm",
     "lint": "tslint -p .",
-    "test": "jest --clearCache"
+    "test": "jest"
   }
 }


### PR DESCRIPTION
In https://github.com/airbrake/airbrake-js/pull/1141 I mistakenly added that flag thinking that it clears cache AND runs tests. After reading the docs more carefully, I realized I was wrong.

It's a miracle nothing broke.