### PR TITLE
browser/src/jsonify_notice: don't filter `context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ### master
 
-- [browser] Fixed relative import issues with Yarn's Plug'n'Play feature
+#### browser
+
+- Fixed relative import issues with Yarn's Plug'n'Play feature
   ([#1135](https://github.com/airbrake/airbrake-js/pull/1135))
+- Stop filtering the `context` field in the notice payload. This payload
+  contains service information and it should never be modified
+  ([#1325](https://github.com/airbrake/airbrake-js/pull/1325))
 
 ### [2.1.7] (October 4, 2021)
 

--- a/packages/browser/src/jsonify_notice.ts
+++ b/packages/browser/src/jsonify_notice.ts
@@ -17,7 +17,7 @@ export function jsonifyNotice(
   }
 
   let s = '';
-  let keys = ['context', 'params', 'environment', 'session'];
+  let keys = ['params', 'environment', 'session'];
   for (let level = 0; level < 8; level++) {
     let opts = { level, keysBlocklist };
     for (let key of keys) {

--- a/packages/browser/tests/jsonify_notice.test.js
+++ b/packages/browser/tests/jsonify_notice.test.js
@@ -87,4 +87,25 @@ describe('jsonify_notice', () => {
       expect(json.length).toBeLessThan(maxLength);
     });
   });
+
+  describe('when called with a blocklisted key', () => {
+    const notice = {
+      params: { name: 'I will be filtered' },
+      session: { session1: 'value1' },
+      context: { notifier: { name: 'airbrake-js' } },
+    };
+    let json;
+
+    beforeEach(() => {
+      json = jsonifyNotice(notice, { keysBlocklist: ['name'] });
+    });
+
+    it('filters out blocklisted keys', () => {
+      expect(JSON.parse(json)).toStrictEqual({
+        params: { name: '[Filtered]' },
+        session: { session1: 'value1' },
+        context: { notifier: { name: 'airbrake-js' } },
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake-js/issues/1301 (Using blocklist with "name" filters out notifier name)

Just like in airbrake-ruby, we must not filter out service information, such as notifier name and version.