### PR TITLE
browser/base_notifier: check for object early in 'notify'

### DIFF
--- a/packages/browser/src/base_notifier.ts
+++ b/packages/browser/src/base_notifier.ts
@@ -115,6 +115,10 @@ export class BaseNotifier {
   }
 
   notify(err: any): Promise<INotice> {
+    if (typeof err !== 'object' || err.error === undefined) {
+      err = { error: err };
+    }
+
     let notice: INotice = {
       errors: [],
       context: {
@@ -126,10 +130,6 @@ export class BaseNotifier {
       environment: err.environment || {},
       session: err.session || {},
     };
-
-    if (typeof err !== 'object' || err.error === undefined) {
-      err = { error: err };
-    }
 
     if (!this._opt.errorNotifications) {
       notice.error = new Error(


### PR DESCRIPTION
We don't really need to build the notice object in order to perform the
'object' check.