### PR TITLE
browser/base_notifier: check for 'error' in 'err' properly

### DIFF
--- a/packages/browser/src/base_notifier.ts
+++ b/packages/browser/src/base_notifier.ts
@@ -115,7 +115,7 @@ export class BaseNotifier {
   }
 
   notify(err: any): Promise<INotice> {
-    if (typeof err !== 'object' || err.error === undefined) {
+    if (typeof err !== 'object' || !('error' in err)) {
       err = { error: err };
     }
 


### PR DESCRIPTION
This check exists because we want to see if the 'error' key was passed when 'err' is an object. In https://github.com/airbrake/airbrake-js/issues/829 we want to add support for "falsey" values, which cannot be reported as of now. This check prevented "undefined" values, that's why we modified it to check for the property's existence, instead of its value.