### PR TITLE
browser/base_notifier: allow reporting of falsey errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   `keysBlocklist` option. It filters out all the data from the notice except the
   specified keys
   ([#1335](https://github.com/airbrake/airbrake-js/pull/1335))
+- Added support for error reporting of "falsey" errors such as `null`, `NaN`,
+  `undefined`, `false`, `""`
+  ([#1345](https://github.com/airbrake/airbrake-js/pull/1345))
 
 ### [2.1.8] (December 6, 2022)
 

--- a/packages/browser/src/base_notifier.ts
+++ b/packages/browser/src/base_notifier.ts
@@ -115,9 +115,10 @@ export class BaseNotifier {
   }
 
   notify(err: any): Promise<INotice> {
-    if (typeof err !== 'object' || !('error' in err)) {
+    if (typeof err !== 'object' || err === null || !('error' in err)) {
       err = { error: err };
     }
+    this.handleFalseyError(err);
 
     let notice = this.newNotice(err);
 
@@ -147,6 +148,18 @@ export class BaseNotifier {
     }
     notice.context.language = 'JavaScript';
     return this._sendNotice(notice);
+  }
+
+  private handleFalseyError(err: any) {
+    if (Number.isNaN(err.error)) {
+      err.error = new Error('NaN');
+    } else if (err.error === undefined) {
+      err.error = new Error('undefined');
+    } else if (err.error === '') {
+      err.error = new Error('<empty string>');
+    } else if (err.error === null) {
+      err.error = new Error('null');
+    }
   }
 
   private newNotice(err: any): INotice {

--- a/packages/browser/src/base_notifier.ts
+++ b/packages/browser/src/base_notifier.ts
@@ -119,17 +119,7 @@ export class BaseNotifier {
       err = { error: err };
     }
 
-    let notice: INotice = {
-      errors: [],
-      context: {
-        severity: 'error',
-        ...this.scope().context(),
-        ...err.context,
-      },
-      params: err.params || {},
-      environment: err.environment || {},
-      session: err.session || {},
-    };
+    let notice = this.newNotice(err);
 
     if (!this._opt.errorNotifications) {
       notice.error = new Error(
@@ -164,6 +154,20 @@ export class BaseNotifier {
     }
     notice.context.language = 'JavaScript';
     return this._sendNotice(notice);
+  }
+
+  private newNotice(err: any): INotice {
+    return {
+      errors: [],
+      context: {
+        severity: 'error',
+        ...this.scope().context(),
+        ...err.context,
+      },
+      params: err.params || {},
+      environment: err.environment || {},
+      session: err.session || {},
+    };
   }
 
   _sendNotice(notice: INotice): Promise<INotice> {

--- a/packages/browser/src/base_notifier.ts
+++ b/packages/browser/src/base_notifier.ts
@@ -130,13 +130,6 @@ export class BaseNotifier {
       return Promise.resolve(notice);
     }
 
-    if (!err.error) {
-      notice.error = new Error(
-        `airbrake: got err=${JSON.stringify(err.error)}, wanted an Error`
-      );
-      return Promise.resolve(notice);
-    }
-
     let error = this._processor(err.error);
     notice.errors.push(error);
 

--- a/packages/browser/tests/client.test.js
+++ b/packages/browser/tests/client.test.js
@@ -257,6 +257,46 @@ describe('Notifier', () => {
       });
     });
 
+    it('reports NaN errors', () => {
+      client.notify(NaN);
+      expect(reporter.mock.calls.length).toEqual(1);
+
+      let notice = reporter.mock.calls[0][0];
+      expect(notice.errors[0].message).toEqual('NaN');
+    });
+
+    it('reports undefined errors', () => {
+      client.notify(undefined);
+      expect(reporter.mock.calls.length).toEqual(1);
+
+      let notice = reporter.mock.calls[0][0];
+      expect(notice.errors[0].message).toEqual('undefined');
+    });
+
+    it('reports empty string errors', () => {
+      client.notify('');
+      expect(reporter.mock.calls.length).toEqual(1);
+
+      let notice = reporter.mock.calls[0][0];
+      expect(notice.errors[0].message).toEqual('<empty string>');
+    });
+
+    it('reports "false"', () => {
+      client.notify(false);
+      expect(reporter.mock.calls.length).toEqual(1);
+
+      let notice = reporter.mock.calls[0][0];
+      expect(notice.errors[0].message).toEqual('false');
+    });
+
+    it('reports "null"', () => {
+      client.notify(null);
+      expect(reporter.mock.calls.length).toEqual(1);
+
+      let notice = reporter.mock.calls[0][0];
+      expect(notice.errors[0].message).toEqual('null');
+    });
+
     it('reports severity', () => {
       client.notify({ error: theErr, context: { severity: 'warning' } });
 
@@ -349,6 +389,46 @@ describe('Notifier', () => {
       it('unwraps and processes error', () => {
         client.notify({ error: theErr });
         expect(reporter.mock.calls.length).toBe(1);
+      });
+
+      it('reports NaN errors', () => {
+        client.notify({ error: NaN });
+        expect(reporter.mock.calls.length).toEqual(1);
+
+        let notice = reporter.mock.calls[0][0];
+        expect(notice.errors[0].message).toEqual('NaN');
+      });
+
+      it('reports undefined errors', () => {
+        client.notify({ error: undefined });
+        expect(reporter.mock.calls.length).toEqual(1);
+
+        let notice = reporter.mock.calls[0][0];
+        expect(notice.errors[0].message).toEqual('undefined');
+      });
+
+      it('reports empty string errors', () => {
+        client.notify({ error: '' });
+        expect(reporter.mock.calls.length).toEqual(1);
+
+        let notice = reporter.mock.calls[0][0];
+        expect(notice.errors[0].message).toEqual('<empty string>');
+      });
+
+      it('reports "false"', () => {
+        client.notify({ error: false });
+        expect(reporter.mock.calls.length).toEqual(1);
+
+        let notice = reporter.mock.calls[0][0];
+        expect(notice.errors[0].message).toEqual('false');
+      });
+
+      it('reports "null"', () => {
+        client.notify({ error: null });
+        expect(reporter.mock.calls.length).toEqual(1);
+
+        let notice = reporter.mock.calls[0][0];
+        expect(notice.errors[0].message).toEqual('null');
       });
 
       it('reports custom context', () => {

--- a/packages/browser/tests/client.test.js
+++ b/packages/browser/tests/client.test.js
@@ -257,18 +257,6 @@ describe('Notifier', () => {
       });
     });
 
-    it('ignores falsey error', (done) => {
-      let promise = client.notify('');
-      expect(reporter.mock.calls.length).toBe(0);
-
-      promise.then((notice) => {
-        expect(notice.error.toString()).toBe(
-          'Error: airbrake: got err="", wanted an Error'
-        );
-        done();
-      });
-    });
-
     it('reports severity', () => {
       client.notify({ error: theErr, context: { severity: 'warning' } });
 
@@ -361,19 +349,6 @@ describe('Notifier', () => {
       it('unwraps and processes error', () => {
         client.notify({ error: theErr });
         expect(reporter.mock.calls.length).toBe(1);
-      });
-
-      it('ignores falsey error', (done) => {
-        let promise = client.notify({ error: null, params: { foo: 'bar' } });
-
-        expect(reporter.mock.calls.length).toBe(0);
-
-        promise.then((notice) => {
-          expect(notice.error.toString()).toBe(
-            'Error: airbrake: got err=null, wanted an Error'
-          );
-          done();
-        });
       });
 
       it('reports custom context', () => {


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake-js/issues/829
("Uncaught undefined" and "Uncaught false" is not showing in console)